### PR TITLE
INTERLOK-3719 - updated moveDirectory method to remove @NotNull

### DIFF
--- a/src/main/java/com/adaptris/filesystem/MoveFileService.java
+++ b/src/main/java/com/adaptris/filesystem/MoveFileService.java
@@ -19,9 +19,8 @@ package com.adaptris.filesystem;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-
 import javax.validation.constraints.NotNull;
-
+import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -52,7 +51,6 @@ public class MoveFileService extends ServiceImp {
   private String newPath;
 
   @AdvancedConfig
-  @NotNull
   @InputFieldDefault(value = "false")
   private Boolean moveDirectory;
 
@@ -121,13 +119,14 @@ public class MoveFileService extends ServiceImp {
   public void setMoveDirectory(Boolean moveDirectory) {
     this.moveDirectory = moveDirectory;
   }
-
+ 
   public MoveFileService withMoveDirectory(Boolean moveDirectory){
     setMoveDirectory(moveDirectory);
     return this;
   }
 
-  public boolean moveDirectory(){
-    return getMoveDirectory() != null ? getMoveDirectory() : false;
+  public boolean moveDirectory() {
+    return BooleanUtils.toBooleanDefaultIfNull(getMoveDirectory(), false);
   }
+  
 }


### PR DESCRIPTION
## Motivation

if you configure the com.adaptris.filesystem.MoveFileService, when you configure in the ui, the field 'move-directory' is hidden in the 'advanced' view and it says it has a default of false. but if you leave it as default, you get an error:
"Error occurred during validation: Move Directory must not be null"

## Modification

* removed @NotNull from the field, as it has a default of false, it'll never be null when processing happens
* updated boolean moveDirectory() method to use BooleanUtils.toBooleanDefaultIfNull

## Result

usage of MoveFileService in UI, allows you to leave move-directory field as default without validation failure on save.

## Testing

build jar, add to interlok, test in ui, create/edit MoveFileService, but leave move-directory as default, ui should let you save form without moaning about validation.
