### PR TITLE
INTERLOK-3566 Remove references to Destination

### DIFF
--- a/src/main/java/com/adaptris/filesystem/DirectoryExtractionMode.java
+++ b/src/main/java/com/adaptris/filesystem/DirectoryExtractionMode.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.filesystem;
 
+import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.ExceptionHelper;
@@ -41,6 +42,7 @@ public class DirectoryExtractionMode implements ExtractionMode {
   @NotBlank
   @Getter
   @Setter
+  @InputFieldHint(expression = true)
   private String outputDirectory;
 
   public DirectoryExtractionMode(){
@@ -58,7 +60,7 @@ public class DirectoryExtractionMode implements ExtractionMode {
       if (getOutputDirectory() == null) {
         messageTempDirectory = new File(System.getProperty("java.io.tmpdir"), adaptrisMessage.getUniqueId());
       } else {
-        messageTempDirectory = new File(adaptrisMessage.resolveObject(getOutputDirectory()).toString());
+        messageTempDirectory = new File(adaptrisMessage.resolve(getOutputDirectory()));
       }
       messageTempDirectory.mkdirs();
       TarArchiveEntry entry;

--- a/src/main/java/com/adaptris/filesystem/DirectoryExtractionMode.java
+++ b/src/main/java/com/adaptris/filesystem/DirectoryExtractionMode.java
@@ -16,19 +16,20 @@
 
 package com.adaptris.filesystem;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.utils.IOUtils;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
-import com.adaptris.core.MessageDrivenDestination;
-import com.adaptris.core.util.ExceptionHelper;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import javax.validation.constraints.NotBlank;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 
 /**
  * @author mwarman
@@ -37,13 +38,16 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("directory-extraction-mode")
 public class DirectoryExtractionMode implements ExtractionMode {
 
-  private MessageDrivenDestination outputDirectory;
+  @NotBlank
+  @Getter
+  @Setter
+  private String outputDirectory;
 
   public DirectoryExtractionMode(){
 
   }
 
-  public DirectoryExtractionMode(MessageDrivenDestination outputDirectory){
+  public DirectoryExtractionMode(String outputDirectory){
     setOutputDirectory(outputDirectory);
   }
 
@@ -54,7 +58,7 @@ public class DirectoryExtractionMode implements ExtractionMode {
       if (getOutputDirectory() == null) {
         messageTempDirectory = new File(System.getProperty("java.io.tmpdir"), adaptrisMessage.getUniqueId());
       } else {
-        messageTempDirectory = new File(getOutputDirectory().getDestination(adaptrisMessage));
+        messageTempDirectory = new File(adaptrisMessage.resolveObject(getOutputDirectory()).toString());
       }
       messageTempDirectory.mkdirs();
       TarArchiveEntry entry;
@@ -74,15 +78,7 @@ public class DirectoryExtractionMode implements ExtractionMode {
     }
   }
 
-  public void setOutputDirectory(MessageDrivenDestination outputDirectory) {
-    this.outputDirectory = outputDirectory;
-  }
-
-  public MessageDrivenDestination getOutputDirectory() {
-    return outputDirectory;
-  }
-
-  public DirectoryExtractionMode withOutputDirectory(MessageDrivenDestination outputDirectory){
+  public DirectoryExtractionMode withOutputDirectory(String outputDirectory){
     setOutputDirectory(outputDirectory);
     return this;
   }

--- a/src/main/java/com/adaptris/filesystem/FileExtractionMode.java
+++ b/src/main/java/com/adaptris/filesystem/FileExtractionMode.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.filesystem;
 
+import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.ExceptionHelper;
@@ -42,11 +43,10 @@ public class FileExtractionMode implements ExtractionMode {
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
-//  private MessageDrivenDestination filenameMatch;
-
   @Getter
   @Setter
   @NotBlank
+  @InputFieldHint(expression = true)
   private String filenameMatch;
 
   public FileExtractionMode(){
@@ -67,7 +67,7 @@ public class FileExtractionMode implements ExtractionMode {
         }
         String entryName = entry.getName();
         if (getFilenameMatch() != null){
-          Pattern pattern = Pattern.compile(adaptrisMessage.resolveObject(getFilenameMatch()).toString());
+          Pattern pattern = Pattern.compile(adaptrisMessage.resolve(getFilenameMatch()));
           if (!pattern.matcher(entryName).matches()){
             log.trace("The entry [{}] does not match filenameMatch [{}] skipping", entryName, getFilenameMatch());
             continue;

--- a/src/main/java/com/adaptris/filesystem/FileExtractionMode.java
+++ b/src/main/java/com/adaptris/filesystem/FileExtractionMode.java
@@ -29,7 +29,6 @@ import org.apache.commons.compress.utils.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.validation.constraints.NotBlank;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.regex.Pattern;
@@ -43,9 +42,11 @@ public class FileExtractionMode implements ExtractionMode {
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
+  /**
+   * A resolvable regular expression to match which files within the archive to extract.
+   */
   @Getter
   @Setter
-  @NotBlank
   @InputFieldHint(expression = true)
   private String filenameMatch;
 

--- a/src/main/java/com/adaptris/filesystem/FileExtractionMode.java
+++ b/src/main/java/com/adaptris/filesystem/FileExtractionMode.java
@@ -16,21 +16,22 @@
 
 package com.adaptris.filesystem;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.regex.Pattern;
-
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.utils.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
-import com.adaptris.core.MessageDrivenDestination;
-import com.adaptris.core.util.ExceptionHelper;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import javax.validation.constraints.NotBlank;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.regex.Pattern;
 
 /**
  * @author mwarman
@@ -41,13 +42,18 @@ public class FileExtractionMode implements ExtractionMode {
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
-  private MessageDrivenDestination filenameMatch;
+//  private MessageDrivenDestination filenameMatch;
+
+  @Getter
+  @Setter
+  @NotBlank
+  private String filenameMatch;
 
   public FileExtractionMode(){
 
   }
 
-  public FileExtractionMode(MessageDrivenDestination filenameMatch){
+  public FileExtractionMode(String filenameMatch){
     setFilenameMatch(filenameMatch);
   }
 
@@ -61,7 +67,7 @@ public class FileExtractionMode implements ExtractionMode {
         }
         String entryName = entry.getName();
         if (getFilenameMatch() != null){
-          Pattern pattern = Pattern.compile(getFilenameMatch().getDestination(adaptrisMessage));
+          Pattern pattern = Pattern.compile(adaptrisMessage.resolveObject(getFilenameMatch()).toString());
           if (!pattern.matcher(entryName).matches()){
             log.trace("The entry [{}] does not match filenameMatch [{}] skipping", entryName, getFilenameMatch());
             continue;
@@ -78,15 +84,7 @@ public class FileExtractionMode implements ExtractionMode {
     }
   }
 
-  public void setFilenameMatch(MessageDrivenDestination filenameMatch) {
-    this.filenameMatch = filenameMatch;
-  }
-
-  public MessageDrivenDestination getFilenameMatch() {
-    return filenameMatch;
-  }
-
-  public FileExtractionMode withFilenameMatch(MessageDrivenDestination filenameMatch){
+  public FileExtractionMode withFilenameMatch(String filenameMatch){
     setFilenameMatch(filenameMatch);
     return this;
   }

--- a/src/main/java/com/adaptris/filesystem/smbj/SMBConsumer.java
+++ b/src/main/java/com/adaptris/filesystem/smbj/SMBConsumer.java
@@ -27,6 +27,7 @@ import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.fs.FsConsumer;
 import com.adaptris.core.ftp.FtpConsumer;
+import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.interlok.cloud.RemoteFile;
 import com.adaptris.interlok.util.FileFilterBuilder;
 import com.hierynomus.msfscc.FileAttributes;
@@ -88,7 +89,7 @@ public class SMBConsumer extends AdaptrisPollingConsumer {
   /**
    * Set the filename filter implementation that will be used for filtering files.
    * <p>
-   * The expression that is used to filter messages, if not specified,
+   * The expression that is used to filter messages is obtained from the {@code fileFilter}, if not specified,
    * then the default is {@code org.apache.commons.io.filefilter.RegexFileFilter} which uses the {@code java.util} regular
    * expressions to perform filtering.
    * </p>
@@ -121,8 +122,6 @@ public class SMBConsumer extends AdaptrisPollingConsumer {
   @Getter
   @Setter
   private String filterExpression;
-
-  private transient boolean destinationWarningLogged = false;
 
   // Always non-null because FileFilterBuilder does that
   protected transient FileFilter fileFilter;
@@ -257,7 +256,7 @@ public class SMBConsumer extends AdaptrisPollingConsumer {
 
   @Override
   protected String newThreadName() {
-    return retrieveAdaptrisMessageListener().friendlyName();
+    return DestinationHelper.threadName(retrieveAdaptrisMessageListener());
   }
 
 }

--- a/src/main/java/com/adaptris/filesystem/smbj/SMBProducer.java
+++ b/src/main/java/com/adaptris/filesystem/smbj/SMBProducer.java
@@ -25,6 +25,7 @@ import com.adaptris.core.FileNameCreator;
 import com.adaptris.core.FormattedFilenameCreator;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.ProduceOnlyProducerImp;
+import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.ExceptionHelper;
 import com.hierynomus.smbj.common.SmbPath;
 import com.hierynomus.smbj.share.File;
@@ -148,7 +149,7 @@ public class SMBProducer extends ProduceOnlyProducerImp {
 
   @Override
   public String endpoint(AdaptrisMessage msg) throws ProduceException {
-    return getPath();
+    return DestinationHelper.resolveProduceDestination(getPath(), msg);
   }
 
   // Probably is just a java.util.BiConsumer really.

--- a/src/main/java/com/adaptris/filesystem/smbj/SMBProducer.java
+++ b/src/main/java/com/adaptris/filesystem/smbj/SMBProducer.java
@@ -15,15 +15,6 @@
  *******************************************************************************/
 package com.adaptris.filesystem.smbj;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Optional;
-
-import javax.validation.Valid;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.ObjectUtils;
-
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
@@ -32,20 +23,23 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.FileNameCreator;
 import com.adaptris.core.FormattedFilenameCreator;
-import com.adaptris.core.ProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.ProduceOnlyProducerImp;
-import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.core.util.LoggingHelper;
-import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.hierynomus.smbj.common.SmbPath;
 import com.hierynomus.smbj.share.File;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.ObjectUtils;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Optional;
 
 /**
  * Produce to a SMB share.
@@ -79,36 +73,19 @@ public class SMBProducer extends ProduceOnlyProducerImp {
   private WriteMode mode;
 
   /**
-   * The destination represents the base-directory where you are producing files to.
-   *
-   */
-  @Getter
-  @Setter
-  @Deprecated
-  @Valid
-  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'path' instead", groups = Deprecated.class)
-  private ProduceDestination destination;
-
-  /**
    * The SMB Path to write files to in the form {@code \\server-name\shareName\path\to\dir}.
    *
    */
   @InputFieldHint(expression = true)
   @Getter
   @Setter
-  // Needs to be @NotBlank when destination is removed.
+  @NotBlank
   private String path;
 
-  private transient boolean destWarning;
-
-
   @Override
-  public void prepare() throws CoreException {
-    DestinationHelper.logWarningIfNotNull(destWarning, () -> destWarning = true, getDestination(),
-        "{} uses destination, use 'path' instead", LoggingHelper.friendlyName(this));
-    DestinationHelper.mustHaveEither(getPath(), getDestination());
+  public void prepare() throws CoreException
+  {
   }
-
 
   @Override
   protected void doProduce(AdaptrisMessage msg, String uncPath) throws ProduceException {
@@ -171,7 +148,7 @@ public class SMBProducer extends ProduceOnlyProducerImp {
 
   @Override
   public String endpoint(AdaptrisMessage msg) throws ProduceException {
-    return DestinationHelper.resolveProduceDestination(getPath(), getDestination(), msg);
+    return getPath();
   }
 
   // Probably is just a java.util.BiConsumer really.

--- a/src/test/java/com/adaptris/filesystem/DirectoryExtractionModeTest.java
+++ b/src/test/java/com/adaptris/filesystem/DirectoryExtractionModeTest.java
@@ -16,11 +16,11 @@
 
 package com.adaptris.filesystem;
 
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ConfiguredDestination;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author mwarman
@@ -31,20 +31,15 @@ public class DirectoryExtractionModeTest {
   public void getOutputDirectory() throws Exception{
     DirectoryExtractionMode extractionMode = new DirectoryExtractionMode();
     assertNull(extractionMode.getOutputDirectory());
-    extractionMode = new DirectoryExtractionMode(new ConfiguredDestination("value"));
+    extractionMode = new DirectoryExtractionMode("value");
     assertNotNull(extractionMode.getOutputDirectory());
-    assertTrue(extractionMode.getOutputDirectory() instanceof ConfiguredDestination);
+    assertEquals("value", extractionMode.getOutputDirectory());
+    extractionMode = new DirectoryExtractionMode().withOutputDirectory("value2");
     assertNotNull(extractionMode.getOutputDirectory());
-    assertTrue(extractionMode.getOutputDirectory() instanceof ConfiguredDestination);
-    assertEquals("value", extractionMode.getOutputDirectory().getDestination(AdaptrisMessageFactory.getDefaultInstance().newMessage()));
-    extractionMode = new DirectoryExtractionMode().withOutputDirectory(new ConfiguredDestination("value2"));
-    assertNotNull(extractionMode.getOutputDirectory());
-    assertTrue(extractionMode.getOutputDirectory() instanceof ConfiguredDestination);
-    assertEquals("value2", extractionMode.getOutputDirectory().getDestination(AdaptrisMessageFactory.getDefaultInstance().newMessage()));
+    assertEquals("value2", extractionMode.getOutputDirectory());
     extractionMode = new DirectoryExtractionMode();
-    extractionMode.setOutputDirectory(new ConfiguredDestination("value3"));
+    extractionMode.setOutputDirectory("value3");
     assertNotNull(extractionMode.getOutputDirectory());
-    assertTrue(extractionMode.getOutputDirectory() instanceof ConfiguredDestination);
-    assertEquals("value3", extractionMode.getOutputDirectory().getDestination(AdaptrisMessageFactory.getDefaultInstance().newMessage()));
+    assertEquals("value3", extractionMode.getOutputDirectory());
   }
 }

--- a/src/test/java/com/adaptris/filesystem/FileExtractionModeTest.java
+++ b/src/test/java/com/adaptris/filesystem/FileExtractionModeTest.java
@@ -16,11 +16,11 @@
 
 package com.adaptris.filesystem;
 
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ConfiguredDestination;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author mwarman
@@ -31,20 +31,15 @@ public class FileExtractionModeTest {
   public void getFilenameMatch() throws Exception{
     FileExtractionMode extractionMode = new FileExtractionMode();
     assertNull(extractionMode.getFilenameMatch());
-    extractionMode = new FileExtractionMode(new ConfiguredDestination("value"));
+    extractionMode = new FileExtractionMode("value");
     assertNotNull(extractionMode.getFilenameMatch());
-    assertTrue(extractionMode.getFilenameMatch() instanceof ConfiguredDestination);
+    assertEquals("value", extractionMode.getFilenameMatch());
+    extractionMode = new FileExtractionMode().withFilenameMatch("value2");
     assertNotNull(extractionMode.getFilenameMatch());
-    assertTrue(extractionMode.getFilenameMatch() instanceof ConfiguredDestination);
-    assertEquals("value", extractionMode.getFilenameMatch().getDestination(AdaptrisMessageFactory.getDefaultInstance().newMessage()));
-    extractionMode = new FileExtractionMode().withFilenameMatch(new ConfiguredDestination("value2"));
-    assertNotNull(extractionMode.getFilenameMatch());
-    assertTrue(extractionMode.getFilenameMatch() instanceof ConfiguredDestination);
-    assertEquals("value2", extractionMode.getFilenameMatch().getDestination(AdaptrisMessageFactory.getDefaultInstance().newMessage()));
+    assertEquals("value2", extractionMode.getFilenameMatch());
     extractionMode = new FileExtractionMode();
-    extractionMode.setFilenameMatch(new ConfiguredDestination("value3"));
+    extractionMode.setFilenameMatch("value3");
     assertNotNull(extractionMode.getFilenameMatch());
-    assertTrue(extractionMode.getFilenameMatch() instanceof ConfiguredDestination);
-    assertEquals("value3", extractionMode.getFilenameMatch().getDestination(AdaptrisMessageFactory.getDefaultInstance().newMessage()));
+    assertEquals("value3", extractionMode.getFilenameMatch());
   }
 }

--- a/src/test/java/com/adaptris/filesystem/TarGZipUnArchiverServiceTest.java
+++ b/src/test/java/com/adaptris/filesystem/TarGZipUnArchiverServiceTest.java
@@ -13,21 +13,22 @@
 
 package com.adaptris.filesystem;
 
-import static org.eclipse.jetty.util.IO.delete;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceCase;
+import com.adaptris.core.util.LifecycleHelper;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import org.junit.Test;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ConfiguredDestination;
-import com.adaptris.core.ServiceCase;
-import com.adaptris.core.util.LifecycleHelper;
+
+import static org.eclipse.jetty.util.IO.delete;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author mwarman
@@ -43,7 +44,7 @@ public class TarGZipUnArchiverServiceTest extends ServiceCase {
     File file = new File(this.getClass().getClassLoader().getResource("archive.tar.gz").getFile());
     byte[] payload = Files.readAllBytes(Paths.get(file.toURI()));
     TarGZipUnArchiverService service =
-        new TarGZipUnArchiverService().withExtractionMode(new FileExtractionMode(new ConfiguredDestination("^file.xml$")));
+        new TarGZipUnArchiverService().withExtractionMode(new FileExtractionMode("^file.xml$"));
     LifecycleHelper.initAndStart(service);
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(payload);
     service.doService(message);
@@ -68,7 +69,7 @@ public class TarGZipUnArchiverServiceTest extends ServiceCase {
     File file = new File(this.getClass().getClassLoader().getResource("archive.tar.gz").getFile());
     byte[] payload = Files.readAllBytes(Paths.get(file.toURI()));
     TarGZipUnArchiverService service =
-        new TarGZipUnArchiverService().withExtractionMode(new FileExtractionMode(new ConfiguredDestination("^dir/file1.xml$")));
+        new TarGZipUnArchiverService().withExtractionMode(new FileExtractionMode("^dir/file1.xml$"));
     LifecycleHelper.initAndStart(service);
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(payload);
     service.doService(message);
@@ -81,7 +82,7 @@ public class TarGZipUnArchiverServiceTest extends ServiceCase {
     File file = new File(this.getClass().getClassLoader().getResource("archive.tar.gz").getFile());
     byte[] payload = Files.readAllBytes(Paths.get(file.toURI()));
     TarGZipUnArchiverService service =
-        new TarGZipUnArchiverService().withExtractionMode(new FileExtractionMode(new ConfiguredDestination("^nomatch.xml$")));
+        new TarGZipUnArchiverService().withExtractionMode(new FileExtractionMode("^nomatch.xml$"));
     LifecycleHelper.initAndStart(service);
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(payload);
     service.doService(message);
@@ -95,7 +96,7 @@ public class TarGZipUnArchiverServiceTest extends ServiceCase {
     File directory = createTempDirectory();
     byte[] payload = Files.readAllBytes(Paths.get(file.toURI()));
     TarGZipUnArchiverService service = new TarGZipUnArchiverService()
-        .withExtractionMode(new DirectoryExtractionMode(new ConfiguredDestination(directory.getAbsolutePath())));
+        .withExtractionMode(new DirectoryExtractionMode(directory.getAbsolutePath()));
     LifecycleHelper.initAndStart(service);
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(payload);
     service.doService(message);


### PR DESCRIPTION
## Motivation

Removal of deprecated classes in interlok-core force update of optionals.

## Modification

Update/remove references to Destination objects, as they no longer exist.

## Result

The user can no longer use Destinations but has to use whatever the replacement is (here it's likely to be a String path)

## Testing

The unit tests should run and pass as before and within the UI the field for Destinations should be removed and an alternative should be present.
