### PR TITLE
Java 17 and junit 5 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,113 +7,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk
-
-    working_directory: ~/project
-
-    environment:
-      JAVA_TOOL_OPTIONS: -Xmx2G -Djava.security.egd=file:/dev/./urandom
-      TERM: dumb
-
-    steps:
-      - checkout
-
-      - run:
-          name: Configure
-          command: |
-            mkdir -p ~/.gradle
-            echo "org.gradle.warning.mode=none" > ~/.gradle/gradle.properties
-
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}
-            - dependencies-{{ .Environment.CIRCLE_JOB}}-
-            - dependencies-
-
-      # run tests!
-      - run:
-          name: Run Tests
-          command: |
-            chmod +x ./gradlew
-            ./gradlew -PverboseTests=true test jacocoTestReport
-
-      - run:
-          name: Save test results
-          command: |
-            mkdir -p ~/test-results/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
-          when: always
-
-      - store_test_results:
-          path: ~/test-results
-
-      - run:
-          name: codecov.io
-          command: bash <(curl -s https://codecov.io/bash)
-
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-            - ~/.gradle/wrapper
-          key: dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}
-
-  publish:
-    docker:
-      - image: circleci/openjdk:8-jdk
-
-    working_directory: ~/project
-
-    environment:
-      JAVA_TOOL_OPTIONS: -Xmx2G -Djava.security.egd=file:/dev/./urandom
-      TERM: dumb
-
-    steps:
-      - checkout
-
-      - run:
-          name: Configure
-          command: |
-            sudo apt-get -y update
-            sudo apt-get -y install graphviz
-            mkdir -p ~/.gradle
-            echo "org.gradle.warning.mode=none" > ~/.gradle/gradle.properties
-
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}
-            - dependencies-{{ .Environment.CIRCLE_JOB}}-
-            - dependencies-
-
-      # run tests!
-      - run:
-          name: Publish
-          command: |
-            chmod +x ./gradlew
-            ./gradlew -PverboseTests=true test publish
-
-      - run:
-          name: Save test results
-          command: |
-            mkdir -p ~/test-results/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
-          when: always
-
-      - store_test_results:
-          path: ~/test-results
-
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-            - ~/.gradle/wrapper
-          key: dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}
-
-  buildjava11:
-    docker:
-      - image: circleci/openjdk:11-jdk
+      - image: circleci/openjdk:17-jdk
 
     working_directory: ~/project
 
@@ -161,8 +55,9 @@ jobs:
             - ~/.gradle/wrapper
           key: dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}
 
+
 workflows:
   version: 2
   on_commit:
     jobs:
-      - buildjava11
+      - build

--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,8 @@ ext.buildInfo = { ->
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 group   = 'com.adaptris'
 version = releaseVersion
 def versionDir = "$buildDir/version"
@@ -139,7 +139,8 @@ dependencies {
 
   annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") {changing= true}
 
-  testImplementation "junit:junit:4.13.2"
+  testImplementation ("org.junit.jupiter:junit-jupiter-api:5.9.2")
+  testImplementation ("org.junit.jupiter:junit-jupiter-engine:5.9.2")
   testImplementation ("org.slf4j:slf4j-simple:$slf4jVersion")
   testImplementation ("com.adaptris:interlok-stubs:$interlokCoreVersion") { changing= true }
   testImplementation ("org.awaitility:awaitility:4.2.0")
@@ -208,9 +209,15 @@ javadoc {
     taglets = ["com.adaptris.taglet.ConfigTaglet", "com.adaptris.taglet.LicenseTaglet"]
     options.addStringOption "tagletpath", configurations.javadoc.asPath
     options.addStringOption('Xdoclint:none', '-quiet')
+    options.addBooleanOption "-no-module-directories", true
     title= componentName
   }
 }
+
+test {
+  jvmArgs = ['--add-opens', 'java.base/java.lang=ALL-UNNAMED', '--add-opens', 'java.base/java.util=ALL-UNNAMED']
+  useJUnitPlatform()
+  }
 
 jacocoTestReport {
     reports {
@@ -269,7 +276,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", componentDesc)
-        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/")
+		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.6.6+")
         properties.appendNode("tags", "filesystem")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@
 @rem limitations under the License.
 @rem
 
-@if "%DEBUG%" == "" @echo off
+@if "%DEBUG%"=="" @echo off
 @rem ##########################################################################
 @rem
 @rem  Gradle startup script for Windows
@@ -25,7 +25,8 @@
 if "%OS%"=="Windows_NT" setlocal
 
 set DIRNAME=%~dp0
-if "%DIRNAME%" == "" set DIRNAME=.
+if "%DIRNAME%"=="" set DIRNAME=.
+@rem This is normally unused
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
@@ -40,7 +41,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto execute
+if %ERRORLEVEL% equ 0 goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -75,13 +76,15 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 :end
 @rem End local scope for the variables with windows NT shell
-if "%ERRORLEVEL%"=="0" goto mainEnd
+if %ERRORLEVEL% equ 0 goto mainEnd
 
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
-exit /b 1
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
 
 :mainEnd
 if "%OS%"=="Windows_NT" endlocal

--- a/src/test/java/com/adaptris/filesystem/ApacheTikaFileProbeTest.java
+++ b/src/test/java/com/adaptris/filesystem/ApacheTikaFileProbeTest.java
@@ -16,13 +16,13 @@
 
 package com.adaptris.filesystem;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
 import com.adaptris.core.DefaultMarshaller;

--- a/src/test/java/com/adaptris/filesystem/CommonsCompressUnzipServiceTest.java
+++ b/src/test/java/com/adaptris/filesystem/CommonsCompressUnzipServiceTest.java
@@ -13,39 +13,35 @@
 
 package com.adaptris.filesystem;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.io.IOException;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.lms.FileBackedMessageFactory;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.filesystem.stubs.DefectiveFileBasedAdaptrisMessage;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
 /**
  * @author mwarman
  */
-public class CommonsCompressUnzipServiceTest extends ServiceCase {
+public class CommonsCompressUnzipServiceTest extends ExampleServiceCase {
 
   private File tempDir;
   private String tempDirCanonicalPath;
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     tempDir = File.createTempFile(CommonsCompressUnzipServiceTest.class.getSimpleName(), "", null);
     tempDir.delete();
@@ -55,7 +51,7 @@ public class CommonsCompressUnzipServiceTest extends ServiceCase {
     tempDirCanonicalPath = tempDir.getCanonicalPath();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     for (final File f : tempDir.listFiles()) {
       f.delete();

--- a/src/test/java/com/adaptris/filesystem/DeleteDirectoryServiceTest.java
+++ b/src/test/java/com/adaptris/filesystem/DeleteDirectoryServiceTest.java
@@ -13,26 +13,22 @@
 
 package com.adaptris.filesystem;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
 /**
  * @author mwarman
  */
-public class DeleteDirectoryServiceTest extends ServiceCase {
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
+public class DeleteDirectoryServiceTest extends ExampleServiceCase {
 
   @Test
   public void testDoServiceDirectoryWithFile() throws Exception {

--- a/src/test/java/com/adaptris/filesystem/DeleteFileServiceTest.java
+++ b/src/test/java/com/adaptris/filesystem/DeleteFileServiceTest.java
@@ -1,37 +1,32 @@
 package com.adaptris.filesystem;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
 /**
  * @author mwarman
  */
-public class DeleteFileServiceTest extends ServiceCase {
+public class DeleteFileServiceTest extends ExampleServiceCase {
 
   private File directoryPath;
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     directoryPath = createTempDirectory();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     cleanUpTempDirectory(directoryPath);
   }

--- a/src/test/java/com/adaptris/filesystem/DirectoryEntityServiceTest.java
+++ b/src/test/java/com/adaptris/filesystem/DirectoryEntityServiceTest.java
@@ -3,9 +3,7 @@ package com.adaptris.filesystem;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -13,35 +11,32 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import static org.eclipse.jetty.util.IO.delete;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DirectoryEntityServiceTest {
-
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testDefaults() {
       final DirectoryEntityService directoryEntityService = new DirectoryEntityService();
-      assertNull("Should instantiate as null", directoryEntityService.getDebugMode());
-      assertNull("Should instantiate as null", directoryEntityService.getMetadataKey());
-      assertNull("Should instantiate as null", directoryEntityService.getDirectoryPath());
-      assertFalse("Should instantiate as false", directoryEntityService.debugMode());
+      assertNull(directoryEntityService.getDebugMode(), "Should instantiate as null");
+      assertNull(directoryEntityService.getMetadataKey(), "Should instantiate as null");
+      assertNull(directoryEntityService.getDirectoryPath(), "Should instantiate as null");
+      assertFalse(directoryEntityService.debugMode(), "Should instantiate as false");
     }
 
     @Test
     public void testSetDetails() {
       final DirectoryEntityService directoryEntityService = new DirectoryEntityService();
-      assertEquals("Should instantiate as null", null, directoryEntityService.getDebugMode());
+      assertEquals(null, directoryEntityService.getDebugMode(), "Should instantiate as null");
 
       directoryEntityService.setDebugMode(true);
       directoryEntityService.setDirectoryPath("Foo");
       directoryEntityService.setMetadataKey("Hello World");
 
-      assertEquals("Should have updated \'getDebugMode\' to true", true, directoryEntityService.getDebugMode());
-      assertEquals("Should have updated \'getDirectoryPath\' to Foo", "Foo", directoryEntityService.getDirectoryPath());
-      assertEquals("Should have updated \'getMetadataKey\' to Hello World", "Hello World", directoryEntityService.getMetadataKey());
-      assertTrue("Should be set to true", directoryEntityService.debugMode());
+      assertEquals(true, directoryEntityService.getDebugMode(), "Should have updated \'getDebugMode\' to true");
+      assertEquals("Foo", directoryEntityService.getDirectoryPath(), "Should have updated \'getDirectoryPath\' to Foo");
+      assertEquals("Hello World", directoryEntityService.getMetadataKey(), "Should have updated \'getMetadataKey\' to Hello World");
+      assertTrue(directoryEntityService.debugMode(), "Should be set to true");
     }
 
     @Test
@@ -53,10 +48,9 @@ public class DirectoryEntityServiceTest {
 
       try {
         directoryEntityService.initService();
-        directoryEntityService.doService(message);
-        exception.expect(ServiceException.class);
-        exception.expectMessage("Directory path is NULL, this service ({}) will not execute.");
-        exception.expectMessage("Missing Required Parameters");
+        assertThrows(ServiceException.class, ()->{
+          directoryEntityService.doService(message);
+        }, "File path null");
       }
 
       catch (ServiceException e) {
@@ -78,14 +72,14 @@ public class DirectoryEntityServiceTest {
         directoryEntityService.setMetadataKey("Foo");
         directoryEntityService.initService();
         directoryEntityService.doService(message);
-
-        exception.expect(FileNotFoundException.class);
-        exception.expectMessage("File not found : " + directoryEntityService.getDirectoryPath());
+        assertThrows(FileNotFoundException.class, ()->{
+          directoryEntityService.doService(message);
+        }, "File not found : " + directoryEntityService.getDirectoryPath());
       }
 
       catch (ServiceException e) {
         final String msg = "java.io.FileNotFoundException: File not found : " + directoryEntityService.getDirectoryPath();
-        assertEquals("Should match error messages", msg, e.getMessage());
+        assertEquals(msg, e.getMessage(), "Should match error messages");
         }
 
       directoryEntityService.prepare();

--- a/src/test/java/com/adaptris/filesystem/DirectoryEntityTest.java
+++ b/src/test/java/com/adaptris/filesystem/DirectoryEntityTest.java
@@ -1,26 +1,25 @@
 package com.adaptris.filesystem;
 
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DirectoryEntityTest {
 
     private File tempDir;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         tempDir = File.createTempFile(DirectoryEntityTest.class.getSimpleName(), "", null);
         tempDir.delete();
@@ -29,7 +28,7 @@ public class DirectoryEntityTest {
         }
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         for (final File f : tempDir.listFiles()) {
             f.delete();
@@ -56,11 +55,11 @@ public class DirectoryEntityTest {
         Date newDate = gCal.getTime();
         directoryEntity.setCreatedAt(newDate);
         //Confirming that directoryEntity is set to defaults
-        assertEquals("Should have same \'getDescription\'", directoryEntity.getDescription(), directoryEntityII.getDescription());
-        assertEquals("Should have identical \'updatedAt\' dates", directoryEntity.getUpdatedAt(), directoryEntityII.getUpdatedAt());
-        assertNotSame("Should have disparate \'getId\' prior to update", directoryEntity.getId(), directoryEntityII.getId());
-        assertNotSame("Should have disparate \'getCreatedAt\'", directoryEntity.getCreatedAt(), directoryEntityII.getCreatedAt());
-        assertNotSame("Should be two unique instances of \'DirectoryEntity\'", directoryEntity, directoryEntityII);
+        assertEquals(directoryEntity.getDescription(), directoryEntityII.getDescription(), "Should have same \'getDescription\'");
+        assertEquals(directoryEntity.getUpdatedAt(), directoryEntityII.getUpdatedAt(), "Should have identical \'updatedAt\' dates");
+        assertNotSame(directoryEntity.getId(), directoryEntityII.getId(), "Should have disparate \'getId\' prior to update");
+        assertNotSame(directoryEntity.getCreatedAt(), directoryEntityII.getCreatedAt(), "Should have disparate \'getCreatedAt\'");
+        assertNotSame(directoryEntity, directoryEntityII, "Should be two unique instances of \'DirectoryEntity\'");
         //Setting new attributes
             directoryEntity.setId("14");
             directoryEntityII.setId("14");
@@ -70,13 +69,13 @@ public class DirectoryEntityTest {
             directoryEntity.setUpdatedAt(newDate);
             directoryEntity.setSize(5000L);
         //Confirming that directoryEntity is updated from defaults
-        assertEquals("Should return \'Hello World\' as \'getParentDirectory\'","Hello World", directoryEntity.getParentDirectory());
-        assertEquals("Should return matching \'getId\'", directoryEntity.getId(), directoryEntityII.getId());
-        assertNotEquals("\'UpdatedAt\' should no longer match", directoryEntity.getUpdatedAt(), directoryEntityII.getUpdatedAt());
-        assertNotEquals("Should have disparate \'getDescription\' after update" , directoryEntity.getDescription(), directoryEntityII.getDescription());
-        assertNotEquals("Should have disparate \'getSize\'", directoryEntity.getSize(), directoryEntityII.getSize());
-        assertTrue("Should match \'newDate\' as the \'getCreatedAt\'", directoryEntity.toString().contains("\"createdAt\":\"2018-12-23T12:30:00+0000\""));
-        assertTrue("Should still be a string type", directoryEntity.toJSON().contains("\"createdAt\":\"2018-12-23T12:30:00+0000\""));
-        assertThat("\'toString\' should return String type", directoryEntity.toJSON(), instanceOf(String.class));
+        assertEquals("Hello World", directoryEntity.getParentDirectory(), "Should return \'Hello World\' as \'getParentDirectory\'");
+        assertEquals(directoryEntity.getId(), directoryEntityII.getId(), "Should return matching \'getId\'");
+        assertNotEquals(directoryEntity.getUpdatedAt(), directoryEntityII.getUpdatedAt(), "\'UpdatedAt\' should no longer match");
+        assertNotEquals(directoryEntity.getDescription(), directoryEntityII.getDescription(), "Should have disparate \'getDescription\' after update");
+        assertNotEquals(directoryEntity.getSize(), directoryEntityII.getSize(), "Should have disparate \'getSize\'");
+        assertTrue(directoryEntity.toString().contains("\"createdAt\":\"2018-12-23T12:30:00+0000\""), "Should match \'newDate\' as the \'getCreatedAt\'");
+        assertTrue(directoryEntity.toJSON().contains("\"createdAt\":\"2018-12-23T12:30:00+0000\""), "Should still be a string type");
+        assertEquals(directoryEntity.toJSON().getClass(), String.class, "\'toString\' should return String type");
     }
 }

--- a/src/test/java/com/adaptris/filesystem/DirectoryExtractionModeTest.java
+++ b/src/test/java/com/adaptris/filesystem/DirectoryExtractionModeTest.java
@@ -16,11 +16,11 @@
 
 package com.adaptris.filesystem;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author mwarman

--- a/src/test/java/com/adaptris/filesystem/DirectoryListingServiceTest.java
+++ b/src/test/java/com/adaptris/filesystem/DirectoryListingServiceTest.java
@@ -13,7 +13,7 @@
 
 package com.adaptris.filesystem;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -22,18 +22,18 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.MetadataDataOutputParameter;
 import com.adaptris.core.common.StringPayloadDataOutputParameter;
 import com.adaptris.core.services.metadata.DateFormatBuilder;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
-public class DirectoryListingServiceTest extends ServiceCase {
+public class DirectoryListingServiceTest extends ExampleServiceCase {
   private static final String METADATA_KEY = "service-test";
   private static final List<String> DEFAULT_PROVIDER_EXPECTED_FILES = Arrays.asList("text1.xml", "text2.xml", "recursive");
   private static final List<String> COMMONS_IO_PROVIDER_EXPECTED_FILES = Arrays.asList("text1.xml", "text2.xml");
@@ -41,17 +41,12 @@ public class DirectoryListingServiceTest extends ServiceCase {
       Arrays.asList("text1.xml", "text2.xml", "text3.xml");
   private String directoryPath;
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     directoryPath = createTempDirectory().getAbsolutePath();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     cleanUpTempDirectory(new File(directoryPath));
   }

--- a/src/test/java/com/adaptris/filesystem/FileExtractionModeTest.java
+++ b/src/test/java/com/adaptris/filesystem/FileExtractionModeTest.java
@@ -16,11 +16,11 @@
 
 package com.adaptris.filesystem;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author mwarman

--- a/src/test/java/com/adaptris/filesystem/MoveFileServiceTest.java
+++ b/src/test/java/com/adaptris/filesystem/MoveFileServiceTest.java
@@ -1,27 +1,24 @@
 package com.adaptris.filesystem;
 
 import static org.eclipse.jetty.util.IO.delete;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+
 
 /**
  * @author mwarman
  */
-public class MoveFileServiceTest extends ServiceCase {
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
+public class MoveFileServiceTest extends ExampleServiceCase {
 
   @Test
   public void testCannotMoveFile() throws Exception {

--- a/src/test/java/com/adaptris/filesystem/TarGZipUnArchiverServiceTest.java
+++ b/src/test/java/com/adaptris/filesystem/TarGZipUnArchiverServiceTest.java
@@ -15,9 +15,10 @@ package com.adaptris.filesystem;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.util.LifecycleHelper;
-import org.junit.Test;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,18 +27,14 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 
 import static org.eclipse.jetty.util.IO.delete;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author mwarman
  */
-public class TarGZipUnArchiverServiceTest extends ServiceCase {
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
+public class TarGZipUnArchiverServiceTest extends ExampleServiceCase {
 
   @Test
   public void testDoServiceFile() throws Exception {

--- a/src/test/java/com/adaptris/filesystem/ZipFolderTest.java
+++ b/src/test/java/com/adaptris/filesystem/ZipFolderTest.java
@@ -14,19 +14,21 @@
 
 package com.adaptris.filesystem;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ZipFolderTest {
   private File tmpDir;
 
-  @Before
+  @BeforeEach
   public void init() {
     tmpDir = new File(System.getProperty("java.io.tmpdir"), "ZipFolderTest");
     if (!tmpDir.exists()) {
@@ -34,7 +36,7 @@ public class ZipFolderTest {
     }
   }
 
-  @After
+  @AfterEach
   public void deinit() {
     for (final File f : tmpDir.listFiles()) {
       f.delete();
@@ -81,10 +83,12 @@ public class ZipFolderTest {
     assertEquals(child, ZipFolder.validateTree(tempDir, child));
   }
 
-  @Test(expected = IOException.class)
+  @Test
   public void testValidateTree_Failure() throws Exception {
     File tempDir = new File(System.getProperty("java.io.tmpdir"));
     File child = new File(tempDir, "../../" + ZipFolderTest.class.getCanonicalName());
-    ZipFolder.validateTree(tempDir, child);
+    assertThrows(IOException.class, ()->{
+      ZipFolder.validateTree(tempDir, child);
+    }, "Invalid file system tree");
   }
 }

--- a/src/test/java/com/adaptris/filesystem/ZipServiceTest.java
+++ b/src/test/java/com/adaptris/filesystem/ZipServiceTest.java
@@ -13,26 +13,21 @@
 
 package com.adaptris.filesystem;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.core.stubs.TempFileUtils;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
-public class ZipServiceTest extends ServiceCase {
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
+public class ZipServiceTest extends ExampleServiceCase {
   
   @Test
   public void testZipDirectoryService() throws Exception {

--- a/src/test/java/com/adaptris/filesystem/smbj/AuthenticationProviderTest.java
+++ b/src/test/java/com/adaptris/filesystem/smbj/AuthenticationProviderTest.java
@@ -15,9 +15,9 @@
  *******************************************************************************/
 package com.adaptris.filesystem.smbj;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import org.junit.jupiter.api.Test;
 
 public class AuthenticationProviderTest {
 

--- a/src/test/java/com/adaptris/filesystem/smbj/ConfigProviderTest.java
+++ b/src/test/java/com/adaptris/filesystem/smbj/ConfigProviderTest.java
@@ -15,11 +15,11 @@
  *******************************************************************************/
 package com.adaptris.filesystem.smbj;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.adaptris.util.TimeInterval;
 import com.hierynomus.smbj.SmbConfig;
 

--- a/src/test/java/com/adaptris/filesystem/smbj/ReadFileServiceTest.java
+++ b/src/test/java/com/adaptris/filesystem/smbj/ReadFileServiceTest.java
@@ -1,8 +1,9 @@
 package com.adaptris.filesystem.smbj;
 
 import static com.adaptris.filesystem.smbj.SMBProducerTest.STANDARD_PAYLOAD;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -10,26 +11,22 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.hierynomus.smbj.SMBClient;
 import com.hierynomus.smbj.connection.Connection;
 import com.hierynomus.smbj.session.Session;
 import com.hierynomus.smbj.share.DiskShare;
 import com.hierynomus.smbj.share.File;
 
-public class ReadFileServiceTest extends ServiceCase {
+public class ReadFileServiceTest extends ExampleServiceCase {
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
@@ -48,11 +45,13 @@ public class ReadFileServiceTest extends ServiceCase {
   }
 
 
-  @Test(expected = ServiceException.class)
+  @Test
   public void testService_Broken() throws Exception {
     AdaptrisMessage msg = new DefectiveMessageFactory(WhenToBreak.BOTH).newMessage();
     ReadFileService service = new ReadFileService().withConnection(new MockConnection()).withPath(SMBProducerTest.SMB_PATH);
-    execute(service, msg);
+    assertThrows(ServiceException.class, ()->{
+      execute(service, msg);
+    }, "Service failed");
   }
 
 

--- a/src/test/java/com/adaptris/filesystem/smbj/SMBConnectionTest.java
+++ b/src/test/java/com/adaptris/filesystem/smbj/SMBConnectionTest.java
@@ -16,12 +16,12 @@
 package com.adaptris.filesystem.smbj;
 
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.filesystem.smbj.SMBConnection.CloseOnExpiry;

--- a/src/test/java/com/adaptris/filesystem/smbj/SMBConsumerTest.java
+++ b/src/test/java/com/adaptris/filesystem/smbj/SMBConsumerTest.java
@@ -17,7 +17,7 @@ package com.adaptris.filesystem.smbj;
 
 import static com.adaptris.filesystem.smbj.SMBProducerTest.SMB_PATH;
 import static com.adaptris.filesystem.smbj.SMBProducerTest.STANDARD_PAYLOAD;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -33,7 +33,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.ConsumerCase;
 import com.adaptris.core.CoreConstants;

--- a/src/test/java/com/adaptris/filesystem/smbj/SMBProducerTest.java
+++ b/src/test/java/com/adaptris/filesystem/smbj/SMBProducerTest.java
@@ -15,19 +15,18 @@
  *******************************************************************************/
 package com.adaptris.filesystem.smbj;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import java.io.ByteArrayOutputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.FormattedFilenameCreator;
-import com.adaptris.core.ProducerCase;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
@@ -38,17 +37,14 @@ import com.hierynomus.smbj.connection.Connection;
 import com.hierynomus.smbj.session.Session;
 import com.hierynomus.smbj.share.DiskShare;
 import com.hierynomus.smbj.share.File;
+import com.adaptris.interlok.junit.scaffolding.ExampleProducerCase;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
-public class SMBProducerTest extends ProducerCase {
+public class SMBProducerTest extends ExampleProducerCase {
 
   public static final String SMB_PATH = "\\\\1.1.1.1\\shareName\\path\\to\\dir";
   public static final String STANDARD_PAYLOAD = "Hello World";
 
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Override
   protected StandaloneProducer retrieveObjectForSampleConfig() {
@@ -65,7 +61,7 @@ public class SMBProducerTest extends ProducerCase {
     StandaloneProducer sp = new StandaloneProducer(new MockConnection(), producer);
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
-    ServiceCase.execute(sp, msg);
+    ExampleServiceCase.execute(sp, msg);
   }
 
   @Test
@@ -75,17 +71,20 @@ public class SMBProducerTest extends ProducerCase {
     StandaloneProducer sp = new StandaloneProducer(new MockConnection(), producer);
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
-    ServiceCase.execute(sp, msg);
+    ExampleServiceCase.execute(sp, msg);
   }
 
-  @Test(expected = ServiceException.class)
+  @Test
   public void testBroken() throws Exception {
     AdaptrisMessage msg = new DefectiveMessageFactory(WhenToBreak.BOTH).newMessage(STANDARD_PAYLOAD);
 
     SMBProducer producer = new SMBProducer().withPath(SMB_PATH);
     StandaloneProducer sp = new StandaloneProducer(new MockConnection(), producer);
+    assertThrows(ServiceException.class, ()->{
+      ExampleServiceCase.execute(sp, msg);
+    }, "Failed service");
 
-    ServiceCase.execute(sp, msg);
+    
 
   }
 

--- a/src/test/java/com/adaptris/filesystem/smbj/WriteModeTest.java
+++ b/src/test/java/com/adaptris/filesystem/smbj/WriteModeTest.java
@@ -15,11 +15,11 @@
  *******************************************************************************/
 package com.adaptris.filesystem.smbj;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import java.io.ByteArrayOutputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.hierynomus.mssmb2.SMB2CreateDisposition;
 import com.hierynomus.smbj.share.File;


### PR DESCRIPTION
## Motivation

Upgrading unit tests for Junit 4 to 5

## Modification

Junit packages changed to the Junit 5 ones
Gradle build file Junit dependency version increased to 5.
Small tweak to assertThrows method as the ordering of the parameters has changed in Junit 5(where it expects your error message).
'@expected' annotation is no longer valid and must now use 'assertThrows' method instead.
Also updating build files to use Java 17 and the required version of Gradle

## PR Checklist

- [x] been self-reviewed.
- [n/a] Added javadocs for most classes and all non-trivial methods
- [n/a] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [n/a] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [n/a] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [n/a] Tested new/updated components in the UI and at runtime in an Interlok instance
- [n/a] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [n/a] Checked that javadoc generation doesn't report errors
- [n/a] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

What's the end result for the user
No changes

## Testing

How can I test this if I'm reviewing this.
If the gradle build is successful and code coverage hasn't dropped then you know it's worked as it means all unit tests ran successfully.